### PR TITLE
Correct 3d

### DIFF
--- a/scripts/warp_3d_script.py
+++ b/scripts/warp_3d_script.py
@@ -46,9 +46,9 @@ ymax = 10.e-6
 
 # Field boundary conditions (longitudinal and transverse respectively)
 f_boundz  = openbc
-f_boundxy = absorb
+f_boundxy = openbc
 # Particles boundary conditions (longitudinal and transverse respectively)
-p_boundz  = absorb
+p_boundz  = reflect
 p_boundxy = reflect
 
 # Moving window (0:off, 1:on)


### PR DESCRIPTION
In the 3D warp script, the boundary conditions that were used were, for some reason, invalid. This lead to weird-looking maps of the fields in the corresponding datasets.

I just set the boundary conditions to correct, valid values, and uploaded the corresponding datasets, which look much better.